### PR TITLE
Add disconnection logs and retry control

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -187,6 +187,8 @@
             let isConnected = false;
             let reconnectTimeout;
             let reconnectAttempts = 0;
+            const MAX_RECONNECT_ATTEMPTS = 5;
+            let waitingForKey = false;
             let manualClose = false;
             let pingTimer;
             let bufferIndex = 0;
@@ -200,6 +202,14 @@
                 const stored = localStorage.getItem('sessionId');
                 if (!stored) {
                     showConnectForm();
+                    return;
+                }
+                if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+                    updateStatus(
+                        'Retry limit reached. Press any key to retry.',
+                        true
+                    );
+                    waitingForKey = true;
                     return;
                 }
                 const delay = Math.min(
@@ -218,11 +228,26 @@
                 }, delay);
             }
 
+            function handleKeyRetry() {
+                if (!waitingForKey) {
+                    return;
+                }
+                waitingForKey = false;
+                reconnectAttempts = 0;
+                const stored = localStorage.getItem('sessionId');
+                if (stored) {
+                    startConnection(
+                        `sessionId=${encodeURIComponent(stored)}&since=${bufferIndex}`
+                    );
+                }
+            }
+
             function clearReconnect() {
                 if (reconnectTimeout) {
                     clearTimeout(reconnectTimeout);
                     reconnectTimeout = null;
                     reconnectAttempts = 0;
+                    waitingForKey = false;
                 }
             }
 
@@ -481,6 +506,7 @@
                 socket.onclose = event => {
                     isConnected = false;
                     clearInterval(pingTimer);
+                    console.log('WebSocket closed', event);
                     if (event.wasClean) {
                         updateStatus('Connection closed', true);
                     } else {
@@ -498,6 +524,7 @@
                 socket.onerror = () => {
                     isConnected = false;
                     clearInterval(pingTimer);
+                    console.log('WebSocket error');
                     updateStatus('Connection failed', true);
                     if (!manualClose) {
                         scheduleReconnect();
@@ -511,6 +538,7 @@
                     window.dataDisposable.dispose();
                 }
                 window.dataDisposable = term.onData(data => {
+                    handleKeyRetry();
                     if (socket && socket.readyState === WebSocket.OPEN) {
                         socket.send(JSON.stringify({ type: 'data', data }));
                     }
@@ -567,6 +595,7 @@
                     socket.close();
                 }
             });
+            window.addEventListener('keydown', handleKeyRetry);
         </script>
     </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -194,6 +194,10 @@
             let bufferIndex = 0;
             const PING_INTERVAL = 15000;
 
+            function log(...args) {
+                console.log(new Date().toISOString(), ...args);
+            }
+
             function showConnectForm() {
                 document.getElementById('connect-form').style.display = 'flex';
             }
@@ -304,9 +308,7 @@
                 if (term && fitAddon) {
                     try {
                         fitAddon.fit();
-                        console.log(
-                            `Terminal resized to: ${term.cols}x${term.rows}`
-                        );
+                        log(`Terminal resized to: ${term.cols}x${term.rows}`);
 
                         // Send resize info to server if connected
                         if (
@@ -364,7 +366,7 @@
                         // Check if container has proper dimensions
                         const container =
                             document.getElementById('terminal-container');
-                        console.log(
+                        log(
                             `Container dimensions: ${container.offsetWidth}x${container.offsetHeight}`
                         );
 
@@ -506,7 +508,7 @@
                 socket.onclose = event => {
                     isConnected = false;
                     clearInterval(pingTimer);
-                    console.log('WebSocket closed', event);
+                    log('WebSocket closed', event);
                     if (event.wasClean) {
                         updateStatus('Connection closed', true);
                     } else {
@@ -524,7 +526,7 @@
                 socket.onerror = () => {
                     isConnected = false;
                     clearInterval(pingTimer);
-                    console.log('WebSocket error');
+                    log('WebSocket error');
                     updateStatus('Connection failed', true);
                     if (!manualClose) {
                         scheduleReconnect();

--- a/public/index.html
+++ b/public/index.html
@@ -220,6 +220,9 @@
                     15000,
                     1000 * Math.pow(2, reconnectAttempts)
                 );
+                log(
+                    `Scheduling reconnect attempt ${reconnectAttempts + 1} in ${delay}ms`
+                );
                 updateStatus(
                     `Reconnecting in ${Math.round(delay / 1000)}s...`,
                     true
@@ -238,6 +241,7 @@
                 }
                 waitingForKey = false;
                 reconnectAttempts = 0;
+                log('Manual key press triggered reconnect');
                 const stored = localStorage.getItem('sessionId');
                 if (stored) {
                     startConnection(
@@ -432,18 +436,21 @@
                 manualClose = false;
                 clearReconnect();
                 clearInterval(pingTimer);
+                log('Opening WebSocket');
                 socket = new WebSocket(
                     `${wsProtocol}//${location.host}/terminal?${query}`
                 );
 
                 socket.onopen = () => {
                     isConnected = true;
+                    log('WebSocket opened');
                     updateStatus('SSH connecting...');
                     document.getElementById('connect-form').style.display =
                         'none';
                     clearReconnect();
                     pingTimer = setInterval(() => {
                         if (socket && socket.readyState === WebSocket.OPEN) {
+                            log('Sending ping');
                             socket.send(JSON.stringify({ type: 'ping' }));
                         }
                     }, PING_INTERVAL);
@@ -453,7 +460,13 @@
                     try {
                         const data = JSON.parse(e.data);
                         if (data.type === 'ping') {
+                            log('Received ping from server');
                             socket.send(JSON.stringify({ type: 'pong' }));
+                            log('Sent pong to server');
+                            return;
+                        }
+                        if (data.type === 'pong') {
+                            log('Received pong from server');
                             return;
                         }
                         if (data.type === 'error') {
@@ -560,6 +573,7 @@
                         manualClose = true;
                         clearReconnect();
                         clearInterval(pingTimer);
+                        log('Closing existing WebSocket');
                         socket.close();
                         terminateSession();
                     }
@@ -574,6 +588,7 @@
                     }
 
                     updateStatus('Connecting...');
+                    log(`Connecting to ${host} as ${user}`);
                     bufferIndex = 0;
                     const query = `host=${encodeURIComponent(host)}&user=${encodeURIComponent(user)}&pass=${encodeURIComponent(pass)}`;
                     startConnection(query);
@@ -594,6 +609,7 @@
                 if (socket && socket.readyState === WebSocket.OPEN) {
                     manualClose = true;
                     clearInterval(pingTimer);
+                    log('Closing WebSocket before unload');
                     socket.close();
                 }
             });


### PR DESCRIPTION
## Summary
- log when SSH sessions or websockets disconnect
- cap websocket reconnect attempts and wait for a key press before retrying
- resume reconnect attempts when the user types

## Testing
- `npm run format:check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68524fb72b04832d83ada77c260c6e3e